### PR TITLE
Remove the anonymous function from onClick

### DIFF
--- a/src/components/RouteNavItem.js
+++ b/src/components/RouteNavItem.js
@@ -2,13 +2,17 @@ import React from "react";
 import { Route } from "react-router-dom";
 import { NavItem } from "react-bootstrap";
 
+const handleClick = (history, event) => {
+    history.push(event.currentTarget.getAttribute("href"))
+}
+
 export default props =>
   <Route
     path={props.href}
     exact
     children={({ match, history }) =>
       <NavItem
-        onClick={e => history.push(e.currentTarget.getAttribute("href"))}
+        onClick={handleClick.bind(this, history)}
         {...props}
         active={match ? true : false}
       >


### PR DESCRIPTION
Remove the anonymous function from the onClick to its' own memory pointer. 
This is to remove the possibility of a memory leak and a performance hit.