### PR TITLE
Changed import of AWS - reduce code size

### DIFF
--- a/src/libs/awsLib.js
+++ b/src/libs/awsLib.js
@@ -1,4 +1,5 @@
-import AWS from "aws-sdk";
+import AWS from 'aws-sdk/global';
+import S3 from 'aws-sdk/clients/s3';
 import { CognitoUserPool } from "amazon-cognito-identity-js";
 import sigV4Client from "./sigV4Client";
 import config from "../config";
@@ -51,7 +52,7 @@ export async function s3Upload(file) {
     throw new Error("User is not logged in");
   }
 
-  const s3 = new AWS.S3({
+  const s3 = new S3({
     params: {
       Bucket: config.s3.BUCKET
     }


### PR DESCRIPTION
Pulled out the S3 dependency, and imported AWS directly from aws-sdk/global.

This makes it possible for webpack to minimize the AWS SDK as the other dependencies don't even enter the picture.

The net impact for me was reducing the javascript file that is downloaded from 1.9MB to 788KB, which was a pretty big win in my book!

Although I'll be honest - it took me longer than I care to admit to find this particular incantation to reduce the bundle size... 😄  


For future people that might read this:
 - Using their minimized SDK was a dead-end, as it would require altering the webpack file from the CreateReactApp, which is possible - but makes it harder to get upstream changes
 - Attempting to import pieces piece-wise a la `import { Config, CognitoIdentityCredentials } from 'aws-sdk'`. Completely works - you just have to pass the `Config` manually into the second arg of `CognitoIdentityCredentials`, as well as change the region on the config directly as a property, but alas this doesn't let Webpack minimize the sdk properly.