### PR TITLE
Avoid rendering of unauthenticated content during authentication

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ class App extends Component {
   async componentDidMount() {
     try {
       if (await authUser()) {
-        this.userHasAuthenticated(true);
+        await this.userHasAuthenticated(true);
       }
     }
     catch(e) {


### PR DESCRIPTION
`this.setState({ isAuthenticating: false });` is called before `this.userHasAuthenticated(true);` finishes, which causes rendering unauthenticated content