### PR TITLE
Update react-router-dom from 5.0 to 5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6229,9 +6229,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -10746,9 +10746,9 @@
       }
     },
     "react-router": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
-      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
@@ -10768,9 +10768,9 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "requires": {
             "isarray": "0.0.1"
           }
@@ -10786,15 +10786,15 @@
       }
     },
     "react-router-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
-      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.0.1",
+        "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "react-bootstrap": "^0.32.4",
     "react-dom": "^16.9.0",
     "react-router-bootstrap": "^0.25.0",
-    "react-router-dom": "^5.0.1",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",
     "react-stripe-elements": "^5.0.1"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { Auth } from "aws-amplify";
-import { Link, withRouter } from "react-router-dom";
+import { Link, withRouter, useHistory } from "react-router-dom";
 import { Nav, Navbar, NavItem } from "react-bootstrap";
 import { LinkContainer } from "react-router-bootstrap";
 import Routes from "./Routes";
 import "./App.css";
 
-function App(props) {
+function App() {
   const [isAuthenticating, setIsAuthenticating] = useState(true);
   const [isAuthenticated, userHasAuthenticated] = useState(false);
+  const history = useHistory();
 
   useEffect(() => {
     onLoad();
@@ -33,7 +34,7 @@ function App(props) {
 
     userHasAuthenticated(false);
 
-    props.history.push("/login");
+    history.push("/login");
   }
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Auth } from "aws-amplify";
-import { Link, withRouter, useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { Nav, Navbar, NavItem } from "react-bootstrap";
 import { LinkContainer } from "react-router-bootstrap";
 import Routes from "./Routes";
@@ -75,4 +75,4 @@ function App() {
   );
 }
 
-export default withRouter(App);
+export default App;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
-import AppliedRoute from "./components/AppliedRoute";
 import AuthenticatedRoute from "./components/AuthenticatedRoute";
 import UnauthenticatedRoute from "./components/UnauthenticatedRoute";
 
@@ -15,12 +14,24 @@ import NotFound from "./containers/NotFound";
 export default function Routes({ appProps }) {
   return (
     <Switch>
-      <AppliedRoute path="/" exact component={Home} appProps={appProps} />
-      <UnauthenticatedRoute path="/login" exact component={Login} appProps={appProps} />
-      <UnauthenticatedRoute path="/signup" exact component={Signup} appProps={appProps} />
-      <AuthenticatedRoute path="/settings" exact component={Settings} appProps={appProps} />
-      <AuthenticatedRoute path="/notes/new" exact component={NewNote} appProps={appProps} />
-      <AuthenticatedRoute path="/notes/:id" exact component={Notes} appProps={appProps} />
+      <Route path="/" exact>
+        <Home {...appProps} />
+      </Route>
+      <UnauthenticatedRoute path="/login" exact appProps={appProps} >
+        <Login {...appProps} />
+      </UnauthenticatedRoute>
+      <UnauthenticatedRoute path="/signup" exact appProps={appProps} >
+        <Signup {...appProps} />
+      </UnauthenticatedRoute>
+      <AuthenticatedRoute path="/settings" exact appProps={appProps} >
+        <Settings />
+      </AuthenticatedRoute>
+      <AuthenticatedRoute path="/notes/new" exact appProps={appProps}>
+        <NewNote />
+      </AuthenticatedRoute>
+      <AuthenticatedRoute path="/notes/:id" exact appProps={appProps}>
+        <Notes />
+      </AuthenticatedRoute>
       {/* Finally, catch all unmatched routes */}
       <Route component={NotFound} />
     </Switch>

--- a/src/components/AppliedRoute.js
+++ b/src/components/AppliedRoute.js
@@ -1,8 +1,0 @@
-import React from "react";
-import { Route } from "react-router-dom";
-
-export default function AppliedRoute({ component: C, appProps, ...rest }) {
-  return (
-    <Route {...rest} render={props => <C {...props} {...appProps} />} />
-  );
-}

--- a/src/components/AuthenticatedRoute.js
+++ b/src/components/AuthenticatedRoute.js
@@ -1,16 +1,15 @@
 import React from "react";
 import { Route, Redirect } from "react-router-dom";
 
-export default function AuthenticatedRoute({ component: C, appProps, ...rest }) {
+export default function AuthenticatedRoute({ children, appProps, ...rest }) {
   return (
     <Route
       {...rest}
-      render={props =>
+      render={({location}) =>
         appProps.isAuthenticated
-          ? <C {...props} {...appProps} />
+          ? children
           : <Redirect
-              to={`/login?redirect=${props.location.pathname}${props.location
-                .search}`}
+              to={`/login?redirect=${location.pathname}${location.search}`}
             />}
     />
   );

--- a/src/components/UnauthenticatedRoute.js
+++ b/src/components/UnauthenticatedRoute.js
@@ -17,14 +17,14 @@ function querystring(name, url = window.location.href) {
   return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
-export default function UnauthenticatedRoute({ component: C, appProps, ...rest }) {
+export default function UnauthenticatedRoute({ children, appProps, ...rest }) {
   const redirect = querystring("redirect");
   return (
     <Route
       {...rest}
-      render={props =>
+      render={() =>
         !appProps.isAuthenticated
-          ? <C {...props} {...appProps} />
+          ? children
           : <Redirect
               to={redirect === "" || redirect === null ? "/" : redirect}
             />}

--- a/src/containers/NewNote.js
+++ b/src/containers/NewNote.js
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import { useHistory } from "react-router-dom";
 import { API } from "aws-amplify";
 import { FormGroup, FormControl, ControlLabel } from "react-bootstrap";
 import LoaderButton from "../components/LoaderButton";
@@ -6,10 +7,11 @@ import { s3Upload } from "../libs/awsLib";
 import config from "../config";
 import "./NewNote.css";
 
-export default function NewNote(props) {
+export default function NewNote() {
   const file = useRef(null);
   const [content, setContent] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const history = useHistory();
 
   function validateForm() {
     return content.length > 0;
@@ -38,7 +40,7 @@ export default function NewNote(props) {
         : null;
 
       await createNote({ content, attachment });
-      props.history.push("/");
+      history.push("/");
     } catch (e) {
       alert(e);
       setIsLoading(false);

--- a/src/containers/Notes.js
+++ b/src/containers/Notes.js
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
+import { useParams, useHistory } from "react-router-dom";
 import { API, Storage } from "aws-amplify";
 import { FormGroup, FormControl, ControlLabel } from "react-bootstrap";
 import LoaderButton from "../components/LoaderButton";
@@ -6,16 +7,18 @@ import { s3Upload } from "../libs/awsLib";
 import config from "../config";
 import "./Notes.css";
 
-export default function Notes(props) {
+export default function Notes() {
   const file = useRef(null);
   const [note, setNote] = useState(null);
   const [content, setContent] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const { id } = useParams();
+  const history = useHistory();
 
   useEffect(() => {
     function loadNote() {
-      return API.get("notes", `/notes/${props.match.params.id}`);
+      return API.get("notes", `/notes/${id}`);
     }
 
     async function onLoad() {
@@ -35,7 +38,7 @@ export default function Notes(props) {
     }
 
     onLoad();
-  }, [props.match.params.id]);
+  }, [id]);
 
   function validateForm() {
     return content.length > 0;
@@ -50,7 +53,7 @@ export default function Notes(props) {
   }
 
   function saveNote(note) {
-    return API.put("notes", `/notes/${props.match.params.id}`, {
+    return API.put("notes", `/notes/${id}`, {
       body: note
     });
   }
@@ -79,7 +82,7 @@ export default function Notes(props) {
         content,
         attachment: attachment || note.attachment
       });
-      props.history.push("/");
+      history.push("/");
     } catch (e) {
       alert(e);
       setIsLoading(false);
@@ -87,7 +90,7 @@ export default function Notes(props) {
   }
 
   function deleteNote() {
-    return API.del("notes", `/notes/${props.match.params.id}`);
+    return API.del("notes", `/notes/${id}`);
   }
 
   async function handleDelete(event) {
@@ -105,7 +108,7 @@ export default function Notes(props) {
 
     try {
       await deleteNote();
-      props.history.push("/");
+      history.push("/");
     } catch (e) {
       alert(e);
       setIsDeleting(false);

--- a/src/containers/Settings.js
+++ b/src/containers/Settings.js
@@ -1,12 +1,14 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { API } from "aws-amplify";
 import { Elements, StripeProvider } from "react-stripe-elements";
 import BillingForm from "../components/BillingForm";
 import config from "../config";
 import "./Settings.css";
 
-export default function Settings(props) {
+export default function Settings() {
   const [isLoading, setIsLoading] = useState(false);
+  const history = useHistory();
 
   function billUser(details) {
     return API.post("notes", "/billing", {
@@ -29,7 +31,7 @@ export default function Settings(props) {
       });
 
       alert("Your card has been charged successfully!");
-      props.history.push("/");
+      history.push("/");
     } catch (e) {
       alert(e);
       setIsLoading(false);

--- a/src/containers/Signup.js
+++ b/src/containers/Signup.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import { Auth } from "aws-amplify";
 import {
   HelpBlock,
@@ -19,6 +20,7 @@ export default function Signup(props) {
   });
   const [newUser, setNewUser] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const history = useHistory();
 
   function validateForm() {
     return (
@@ -60,7 +62,7 @@ export default function Signup(props) {
       await Auth.signIn(fields.email, fields.password);
 
       props.userHasAuthenticated(true);
-      props.history.push("/");
+      history.push("/");
     } catch (e) {
       alert(e.message);
       setIsLoading(false);


### PR DESCRIPTION
Thanks a lot for such a great guide! learned some cool things about Serverless, AWS, DynamoDb and React.

While going through tutorial I noticed that `react-router-dom` dependency is not updated to its latest version. This pull request fixes it by updating it from 5.0 to 5.1 version. 

To know more about 5.1 version update, check out the maintainer's [blog post](https://reacttraining.com/blog/react-router-v5-1/).

Here are key updates related to in this pull request:
-  Code was refactored with newly introduced`useParams` and `useHistory` hooks.
-  `Routes` component was refactored to use `<Route children>` instead of `<Route component>` pattern. This way feels simpler to me. Also, this way is recommended by the maintainer (see their blog post).
 - Now there is no need in `AppliedRoute.js`, so this file was deleted.

Please let me know what you think about this pull request. If all is fine, I will update the tutorial steps.

I will soon create pull requests to other branches.